### PR TITLE
Refactor and upgrade everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Code FREAK IDE Docker Image
 ==
-[![Build Status](https://travis-ci.com/code-freak/ide.svg?branch=master)](https://travis-ci.com/code-freak/ide)
+[![Build Status](https://travis-ci.com/codefreak/ide.svg?branch=master)](https://travis-ci.com/codefreak/ide)
+[![Docker Image Version](https://img.shields.io/docker/v/cfreak/ide?sort=semver)](https://hub.docker.com/r/cfreak/ide)
 
 This is the default IDE image used by [`code-freak`](https://github.com/code-freak/code-freak). It spins up
 an editor on the server that is accessible via browser.  
@@ -8,19 +9,32 @@ Currently we use [`code-server`](https://github.com/cdr/code-server) as IDE.
 
 **Please open Issues on the [main repository](https://github.com/code-freak/code-freak)!**
 
+# Build
+
+Run Docker build in the repository main directory:
+```
+docker build -t cfreak/ide .
+```
+
+# Run / Install
+To run the IDE in the current directory:
+```
+docker run -it --rm -v $PWD:/home/coder/project -p 3000:3000 cfreak/ide:test
+```
+The IDE will be listing on `http://localhost:3000`
+
 # Pre-Installed Languages (+ VSCode Plugins)
 
 * NodeJS 12.16.3 LTS (+ npm & yarn)
- * [`dbaeumer.vscode-eslint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+  * [`dbaeumer.vscode-eslint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 * Python 3.8
   * [`ms-python.python`](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 * OpenJDK 11 LTS
- * [`redhat.java`](https://marketplace.visualstudio.com/items?itemName=redhat.java)
- * [`vscjava.vscode-java-debug`](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
-* C / C++
- * [`ms-vscode.cpptools`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
-* Mono 6.8.0 + Microsoft .NET Core SDK 3.1
- * [`ms-dotnettools.csharp`](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
-
- ## Additional useful Plugins
-* [`formulahendry.code-runner`](https://marketplace.visualstudio.com/items?itemName=formulahendry.code-runner)
+  * [`redhat.java`](https://marketplace.visualstudio.com/items?itemName=redhat.java)
+  * [`vscjava.vscode-java-debug`](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
+* C / C++ (gcc, cmake)
+  * [`ms-vscode.cpptools`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
+* C# by Mono 6.8.0 + Microsoft .NET Core SDK 3.1
+  * [`ms-dotnettools.csharp`](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
+* Other plugins
+  * [`formulahendry.code-runner`](https://marketplace.visualstudio.com/items?itemName=formulahendry.code-runner)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ an editor on the server that is accessible via browser.
 Currently we use [`code-server`](https://github.com/cdr/code-server) as IDE.
 
 **Please open Issues on the [main repository](https://github.com/code-freak/code-freak)!**
+
+# Pre-Installed Languages (+ VSCode Plugins)
+
+* NodeJS 12.16.3 LTS (+ npm & yarn)
+ * [`dbaeumer.vscode-eslint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+* Python 3.8
+  * [`ms-python.python`](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+* OpenJDK 11 LTS
+ * [`redhat.java`](https://marketplace.visualstudio.com/items?itemName=redhat.java)
+ * [`vscjava.vscode-java-debug`](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
+* C / C++
+ * [`ms-vscode.cpptools`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
+* Mono 6.8.0 + Microsoft .NET Core SDK 3.1
+ * [`ms-dotnettools.csharp`](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
+
+ ## Additional useful Plugins
+* [`formulahendry.code-runner`](https://marketplace.visualstudio.com/items?itemName=formulahendry.code-runner)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Code FREAK IDE Docker Image
 [![Build Status](https://travis-ci.com/codefreak/ide.svg?branch=master)](https://travis-ci.com/codefreak/ide)
 [![Docker Image Version](https://img.shields.io/docker/v/cfreak/ide?sort=semver)](https://hub.docker.com/r/cfreak/ide)
 
-This is the default IDE image used by [`code-freak`](https://github.com/code-freak/code-freak). It spins up
+This is the default IDE image used by [Code FREAK](https://github.com/codefreak/codefreak). It spins up
 an editor on the server that is accessible via browser.  
 Currently we use [`code-server`](https://github.com/cdr/code-server) as IDE.
 
-**Please open Issues on the [main repository](https://github.com/code-freak/code-freak)!**
+**Please open issues on the [main repository](https://github.com/codefreak/codefreak)!**
 
 # Build
 
@@ -21,7 +21,7 @@ To run the IDE in the current directory:
 ```
 docker run -it --rm -v $PWD:/home/coder/project -p 3000:3000 cfreak/ide:test
 ```
-The IDE will be listing on `http://localhost:3000`
+The IDE will be listening on `http://localhost:3000`
 
 # Pre-Installed Languages (+ VSCode Plugins)
 

--- a/scripts/install-ext-runtime-deps.sh
+++ b/scripts/install-ext-runtime-deps.sh
@@ -1,0 +1,57 @@
+#! /bin/env bash
+# Utility script to preinstall runtime dependencies of VSCode extensions
+# This seems propritary to Microsoft's C# extension (ms-dotnettools.csharp)
+#
+# Dependencies:
+#  - jq to parse package.json
+#  - curl to download archives
+#  - unzip to extract archives
+#
+# Usage:
+#  ./install-ext-runtime-deps.sh [absolte path to extension installation dir conainting package.json]
+# Example:
+#  ./install-ext-runtime-deps.sh /home/coder/.local/share/code-server/extensions/ms-dotnettools.csharp-*
+
+set -e
+
+ext_dir="$(realpath "$1")"
+
+if [ ! -f "$ext_dir/package.json" ]; then
+    echo "Directory does not contain any package.json!";
+    exit 1
+fi
+
+echo -e "Installing runtimeDependencies of $ext_dir\n"
+
+# Read all runtime deps into an array where each object contains
+# installPath, url, binaries
+declare -a runtime_deps=($(jq --compact-output '.runtimeDependencies[] | select(.platforms[] | contains("linux")) | select(.architectures[] | contains("x86_64")) | {installPath: .installPath, url: .url, binaries: .binaries}' "$ext_dir/package.json"))
+
+for dep in ${runtime_deps[@]}; do
+    install_path="$ext_dir/$(echo "$dep" | jq -r ".installPath")"
+    url="$(echo "$dep" | jq -r ".url")"
+    binaries=($(echo "$dep" | jq -r ".binaries[]"))
+    basename="${url##*/}"
+    tmp_file="$ext_dir/$basename"
+
+    echo -e "Downloading $url...\n"
+    curl -Lo "$tmp_file" "$url"
+    echo -e "Extracting $basename to $install_path...\n"
+    # nuke everything in our destination dir to prevent "replace XYZ" questions by unzip
+    rm -rf "$install_path"
+    mkdir -p "$install_path"
+    # unzip extracts archives with "backwards slashes warning" fine but finishes with exit code 1
+    unzip -q "$tmp_file" -d "$install_path" || true
+    rm "$tmp_file"
+
+    for binary in "${binaries[@]}"; do
+        echo -e "Making $install_path/$binary executable\n"
+        # seems like there are some binaries that do not exist anymore
+        [ -f "$install_path/$binary" ] && chmod u+x "$install_path/$binary"
+    done
+    # Mark dependencies
+    touch "$install_path/install.complete"
+    touch "$install_path/install.Lock"
+done
+
+echo -e "Done installing ${#runtime_deps[@]} runtime dependencies.\n"

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -9,5 +9,6 @@
         "**/.sonarlint": true
     },
     "files.autoSave": "afterDelay",
-    "workbench.startupEditor": "readme"
+    "workbench.startupEditor": "readme",
+    "terminal.integrated.shell.linux": "/bin/bash"
 }


### PR DESCRIPTION
* Update base image to Ubuntu 20.04 LTS
* Upgrade code-server to v3.3.1 and install via .deb
* Use code-server binary to install extensions from marketplace
* Add Mono + VSCode extension
* Remove user from sudoers
* Configure bash as default shell
* Explicitly install python 3.8 + pip
* Switch to OpenJDK 11 and add Maven